### PR TITLE
Hide event log panel

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -149,7 +149,7 @@ body::after {
 .app-main {
   flex: 1 1 auto;
   display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: clamp(20px, 4vw, 36px);
   padding: 0 clamp(20px, 5vw, 48px) clamp(28px, 5vw, 48px);
 }
@@ -316,8 +316,7 @@ button:disabled {
 }
 
 .event-panel {
-  display: flex;
-  align-items: stretch;
+  display: none !important;
 }
 
 .panel-card {
@@ -355,7 +354,7 @@ button:disabled {
 
 @media (max-width: 1200px) {
   .app-main {
-    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the main layout grid to a single column now that the log panel is hidden
- hide the event log panel so it no longer displays in the interface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c601a10c83318dd6ae7f9af46c1d